### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 ## Content Creation Tools
 
+- [WebCoreLab](https://webcorelab.com) — AI content factory + SEO audit. Anti-AI-detection humanizer, GEO/AEO optimization, 272-check technical audit.
 * **[Canva](https://www.canva.com/)** - A design tool for creating visuals, infographics, and social media content.
 * **[Grammarly](https://www.grammarly.com/)** - A writing assistant for improving grammar, tone, and readability.
 * **[Jasper](https://www.jasper.ai/)** - AI-powered content generation for blog posts, ads, and more.


### PR DESCRIPTION
Hi! Adding WebCoreLab to the SEO Tools section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
