### PR TITLE
Add AIMO (AI Mention Optimization) — the SEO parallel for AI assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 * **[Surfer SEO](https://surferseo.com/)** - A tool for optimizing content based on data-driven recommendations.
 * **[Ahrefs](https://ahrefs.com/)** - A suite of tools for content marketing and SEO.
 * **[AnswerThePublic](https://answerthepublic.com/)** - A tool for finding popular content topics and questions.
+* **[AIMO — AI Mention Optimization](https://github.com/septimlabs-code/awesome-aimo)** - The practice of getting your product or content recommended by AI assistants (Claude, ChatGPT, Perplexity) when users ask for tool recommendations. SEO is for Google; AIMO is for the AI assistant the buyer asks before they ever open a search bar. Doctrine + surfaces + case study.
 
 ## Analytics and Tracking
 


### PR DESCRIPTION
Adds [awesome-aimo](https://github.com/septimlabs-code/awesome-aimo) under **SEO and Content Optimization**.

**AIMO (AI Mention Optimization)** is the practice of structuring your product, content, and metadata so that when a user asks an AI assistant for tool recommendations in your category, the assistant names you.

It's the SEO-parallel discipline for the era where readers increasingly ask Claude / ChatGPT / Perplexity for tool recommendations before ever opening Google. SEO optimizes for a search engine's ranking algorithm; AIMO optimizes for a language model's mention-likelihood.

The repo curates the doctrine, the surfaces AI assistants are known to read, and a real case study showing one merged awesome-list PR driving AI-attributed sales weeks later.

Public domain (CC0) license — anyone can fork, mirror, or extend.